### PR TITLE
Update NextMapChanges

### DIFF
--- a/NextMapChanges
+++ b/NextMapChanges
@@ -1,6 +1,10 @@
 Next map changes:
 
-- Remove &k from deluxe tags
+ Remove &k &n and &l from deluxe tags
 - Redo the ftop system with updated plugin
 - Implement a level up system for XP
 - Create a simple and easy to use kit GUI, allow to preview kits aswell
+ Create new email settings/mailbox (FORUMS) so that players receive their confirmation emails
+ Redo the Skyblock shop prices to balance the eco out
+ Remove vote party keys to prevent alts afking farming keys
+ Add purchaseable "Tags" from buy.venompvp.org to Skyblock


### PR DESCRIPTION
- Remove &k &n and &l from deluxe tags { Its not worth the chat looking like shit for an extra $0.50. Keep the tags 1 size, no bold and italics and ugly tags }

 + Redo the Skyblock shop prices to balance the eco out 
 + Remove vote party keys to prevent alts afking farming keys
{ SB is mainly fucked due to these two - Shop prices need to be balanced out in accordance to selling prices and what was too OP this reset. Vote Party Key farming is another problem on SB, alts under a VPN just afk gaining 20+ Vote Party Keys in 2 days }

+ Add purchaseable "Tags" from buy.venompvp.org to Skyblock - { People on Skyblock want tags, Why not give it them :) }